### PR TITLE
Restrict dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About zarr
 ==========
 
-Home: https://github.com/alimanfoo/zarr
+Home: https://github.com/zarr-developers/zarr
 
 Package license: MIT
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - nosetests -v zarr
 
 about:
-  home: https://github.com/alimanfoo/zarr
+  home: https://github.com/zarr-developers/zarr
   license: MIT
   license_file: LICENSE
   summary: An implementation of chunked, compressed, N-dimensional arrays for Python.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,11 +20,11 @@ requirements:
     - toolchain
     - python
     - cython
-    - setuptools
-    - setuptools_scm
+    - setuptools >18.0
+    - setuptools_scm >1.5.4
   run:
     - python
-    - numpy
+    - numpy >=1.7
     - fasteners
 
 test:


### PR DESCRIPTION
Adds the dependency version constrains from the `setup.py` file. Bumps the build number to rebuild the package with these constraints.