### PR TITLE
Set deploy label back to main

### DIFF
--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -58,7 +58,7 @@ conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
 conda build /recipe_root --quiet || exit 1
-upload_or_check_non_existence /recipe_root conda-forge --channel=rc || exit 1
+upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
 touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,6 +4,3 @@ travis:
 appveyor:
   secure:
     BINSTAR_TOKEN: ipv/06DzgA7pzz2CIAtbPxZSsphDtF+JFyoWRnXkn3O8j7oRe3rzqj3LOoq2DZp4
-channels:
-  targets:
-    - [conda-forge, rc]


### PR DESCRIPTION
Forgot to mention we needed to switch from `rc` back to `main`. Sorry @alimanfoo for missing this. Anyways this corrects it so the package is published under `main` (as was the case on `master` previously).