### PR TITLE
Use pip

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,11 +14,12 @@ source:
 build:
   number: 0
   noarch: python
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
+    - pip
     - setuptools >18.0
     - setuptools_scm >1.5.4
   run:


### PR DESCRIPTION
Building of conda-forge packages has moved to [using `pip`]( https://conda-forge.org/docs/meta.html#use-pip ). This is particularly important for `noarch: python` packages. Hence this does this for `zarr`.